### PR TITLE
chore: update HVO.Core from 1.0.0 to 1.1.0

### DIFF
--- a/benchmarks/HVO.Common.Benchmarks/HVO.Common.Benchmarks.csproj
+++ b/benchmarks/HVO.Common.Benchmarks/HVO.Common.Benchmarks.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="HVO.Core" Version="1.0.0" />
+    <PackageReference Include="HVO.Core" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/HVO.Common.Tests/HVO.Common.Tests.csproj
+++ b/tests/HVO.Common.Tests/HVO.Common.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HVO.Core" Version="1.0.0" />
+    <PackageReference Include="HVO.Core" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Update HVO.Core package reference from 1.0.0 to 1.1.0 to align with the latest published version on nuget.org.

## Changes

- `tests/HVO.Common.Tests/HVO.Common.Tests.csproj`: HVO.Core 1.0.0 → 1.1.0
- `benchmarks/HVO.Common.Benchmarks/HVO.Common.Benchmarks.csproj`: HVO.Core 1.0.0 → 1.1.0

## Verification

- `dotnet build` succeeds with 0 errors, 0 warnings
- HVO.Common.Tests: 120 passed, 0 failed
- HVO.Enterprise.Telemetry.Tests: 1264 passed, 0 failed, 1 skipped
